### PR TITLE
Make created reducers not depend on typescript-fsa

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,10 @@
-import { Action, ActionCreator, AnyAction, isType } from "typescript-fsa";
+import { Action, ActionCreator, isType } from "typescript-fsa";
+
+// Redeclare AnyAction from typescript-fsa so modules can export reducers created by this library
+// without requiring a dependency on typescript-fsa.
+export interface AnyAction {
+    type: any;
+}
 
 export interface ReducerBuilder<InS extends OutS, OutS> {
     case<P>(actionCreator: ActionCreator<P>, handler: Handler<InS, OutS, P>): ReducerBuilder<InS, OutS>;


### PR DESCRIPTION
This resolves a typing issue when a reducer is created in one module and
consumed in another module. Since created reducers have types which
include AnyAction, they cannot be exported from a module without also
exporting types from typescript-fsa. The change redeclares AnyAction to
avoid this.