### PR TITLE
Additional fix to exported types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,4 @@
-import { Action, ActionCreator, isType } from "typescript-fsa";
-
-// Redeclare AnyAction from typescript-fsa so modules can export reducers created by this library
-// without requiring a dependency on typescript-fsa.
-export interface AnyAction {
-    type: any;
-}
+import { Action, ActionCreator, AnyAction, isType } from "typescript-fsa";
 
 export interface ReducerBuilder<InS extends OutS, OutS> {
     case<P>(actionCreator: ActionCreator<P>, handler: Handler<InS, OutS, P>): ReducerBuilder<InS, OutS>;
@@ -12,7 +6,9 @@ export interface ReducerBuilder<InS extends OutS, OutS> {
         actionCreator: ActionCreator<P>,
         handler: Handler<InS, OutS, Action<P>>,
     ): ReducerBuilder<InS, OutS>;
-    build(): (state: InS, action: AnyAction) => OutS;
+    // Intentionally avoid AnyAction type so modules can export reducers created using .build()
+    // without requiring a dependency on typescript-fsa.
+    build(): (state: InS, action: { type: any }) => OutS;
     (state: InS, action: AnyAction): OutS;
 }
 


### PR DESCRIPTION
The reducer created by .build() now has no type dependencies on either
of typescript-fsa or typescript-fsa-reducers.