### PR TITLE
Change type definitions to allow passing undefined as state to a reducer

### DIFF
--- a/__tests__/test.ts
+++ b/__tests__/test.ts
@@ -47,18 +47,14 @@ describe("reducer builder", () => {
 
     it("should return an initial value if state is undefined if no cases provided", () => {
         const reducer = reducerWithInitialState(initialState);
-        expect(reducer(undefined as any, { type: "UNKNOWN" })).toBe(
-            initialState,
-        );
+        expect(reducer(undefined, { type: "UNKNOWN" })).toBe(initialState);
     });
 
     it("should return an initial value if state is undefined if cases provided", () => {
         const reducer = reducerWithInitialState(initialState)
             .case(sliceData, sliceDataHandler)
             .case(dataToUpperCase, dataToUpperCaseHandler);
-        expect(reducer(undefined as any, { type: "UNKNOWN" })).toBe(
-            initialState,
-        );
+        expect(reducer(undefined, { type: "UNKNOWN" })).toBe(initialState);
     });
 
     it("should call handler on matching action with single handler", () => {
@@ -87,7 +83,7 @@ describe("reducer builder", () => {
             meta: { author: action.meta && action.meta.author },
         }));
         expect(
-            reducer(undefined as any, sliceData(1, { author: "cbrontë" })),
+            reducer(undefined, sliceData(1, { author: "cbrontë" })),
         ).toEqual({
             data: "ello",
             meta: { author: "cbrontë" },
@@ -163,7 +159,7 @@ describe("reducer builder", () => {
         const reducer = reducerWithInitialState(initialState);
         reducer.case(sliceData, sliceDataHandler);
         reducer.case(dataToUpperCase, dataToUpperCaseHandler);
-        expect(reducer(undefined as any, sliceData(1))).toEqual({
+        expect(reducer(undefined, sliceData(1))).toEqual({
             data: "ello",
         });
     });
@@ -179,7 +175,7 @@ describe("reducer builder", () => {
         });
 
         it("should return a function which behaves like the reducer", () => {
-            expect(reducer(undefined as any, sliceData(1))).toEqual({
+            expect(reducer(undefined, sliceData(1))).toEqual({
                 data: "ello",
             });
         });
@@ -189,10 +185,10 @@ describe("reducer builder", () => {
             const reducer1 = builder.build();
             builder.case(sliceData, sliceDataHandler);
             const reducer2 = builder.build();
-            expect(reducer1(undefined as any, sliceData(1))).toEqual({
+            expect(reducer1(undefined, sliceData(1))).toEqual({
                 data: "hello",
             });
-            expect(reducer2(undefined as any, sliceData(1))).toEqual({
+            expect(reducer2(undefined, sliceData(1))).toEqual({
                 data: "ello",
             });
         });

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,8 +74,8 @@ export interface ReducerBuilder<InS extends OutS, OutS> {
 
     // Intentionally avoid AnyAction type so packages can export reducers
     // created using .build() without requiring a dependency on typescript-fsa.
-    build(): (state: InS, action: { type: any }) => OutS;
-    (state: InS, action: AnyAction): OutS;
+    build(): (state: InS | undefined, action: { type: any }) => OutS;
+    (state: InS | undefined, action: AnyAction): OutS;
 }
 
 export type Handler<InS extends OutS, OutS, P> = (


### PR DESCRIPTION
See https://github.com/dphilipson/typescript-fsa-reducers/issues/21

As far as I can tell there's no downside to making this change, but let me know if I've missed something.