### PR TITLE
Add .getActionCreatorsUsedInCases() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ the action.
     + [`.withHandling(updateBuilder(builder) => builder)`](#withhandlingupdatebuilderbuilder--builder)
     + [`.default(handler(state, action) => newState)`](#defaulthandlerstate-action--newstate)
     + [`.build()`](#build)
+    + [`.getActionCreatorsUsedInCases()`](#getactioncreatorsusedincases)
 
 <!-- tocstop -->
 
@@ -401,5 +402,24 @@ const reducer = reducerWithInitialState(INITIAL_STATE)
     .case(setIsFrozen, setIsFrozenHandler)
     .build();
 ```
+
+#### `.getActionCreatorsUsedInCases()`
+
+Returns an array of the action creators that are used in the reducer chain. This
+list is useful, e.g., when you want to reset the state in another reducer when
+any of the actions affecting the state in the current reducer are dispatched.
+
+```javascript
+const userAccountReducer = reducerWithInitialState(USER_ACCOUNT_INITIAL_STATE)
+    .case(signIn, signInHandler)
+    .case(signOut, signOutHandler);
+
+const userAccountModifiers = userAccountReducer.getActionCreatorsUsedInCases();
+
+// Reset user data when the user account changes.
+const userDataReducer = reducerWithInitialState(USER_DATA_INITIAL_STATE)
+    .cases(userAccountModifiers, state => USER_DATA_INITIAL_STATE);
+```
+
 
 Copyright © 2017 David Philipson

--- a/__tests__/test.ts
+++ b/__tests__/test.ts
@@ -250,6 +250,19 @@ describe("reducer builder", () => {
         });
     });
 
+    it("returns action creators used in cases", () => {
+        const reducer = reducerWithInitialState(initialState);
+        expect(reducer.getActionCreatorsUsedInCases()).toEqual([]);
+        reducer.case(sliceData, sliceDataHandler);
+        expect(reducer.getActionCreatorsUsedInCases()).toEqual([sliceData]);
+        reducer.cases([dataToUpperCase, toBasicState], state => state);
+        expect(reducer.getActionCreatorsUsedInCases()).toEqual([
+            sliceData,
+            dataToUpperCase,
+            toBasicState,
+        ]);
+    });
+
     it("should apply handling function to itself in .withHandling()", () => {
         const handling = (
             builder: ReducerBuilder<State>,

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,6 +78,8 @@ export interface ReducerBuilder<InS extends OutS, OutS = InS> {
         ) => ReducerBuilder<InS, OutS>,
     ): ReducerBuilder<InS, OutS>;
 
+    getActionCreatorsUsedInCases(): ReadonlyArray<ActionCreator<unknown>>;
+
     // Intentionally avoid AnyAction in return type so packages can export reducers
     // created using .default() or .build() without requiring a dependency on typescript-fsa.
     default(
@@ -162,6 +164,9 @@ function makeReducer<InS extends OutS, OutS>(
             builder: ReducerBuilder<InS, OutS>,
         ) => ReducerBuilder<InS, OutS>,
     ) => updateBuilder(reducer);
+
+    reducer.getActionCreatorsUsedInCases = () =>
+        cases.map(c => c.actionCreator);
 
     reducer.default = (defaultHandler: Handler<InS, OutS, AnyAction>) =>
         getReducerFunction(initialState, cases.slice(), defaultHandler);


### PR DESCRIPTION
Returns an array of the action creators that are used in the reducer chain. This list is useful, e.g., when you want to reset the state in another reducer when any of the actions affecting the state in the current reducer are dispatched.

```javascript
const userAccountReducer = reducerWithInitialState(USER_ACCOUNT_INITIAL_STATE)
    .case(signIn, signInHandler)
    .case(signOut, signOutHandler);

const userAccountModifiers = userAccountReducer.getActionCreatorsUsedInCases();

// Reset user data when the user account changes.
const userDataReducer = reducerWithInitialState(USER_DATA_INITIAL_STATE)
    .cases(userAccountModifiers, state => USER_DATA_INITIAL_STATE);
```